### PR TITLE
V1.0.3 - fix PeachpieVendorStubsAssemblyFile 

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <!-- version -->
     <AvaloniaVersion>11.3.5</AvaloniaVersion>
     <PeachpieVersion>1.1.11</PeachpieVersion>
-    <Version Condition=" '$(Version)'=='' ">1.0.2</Version>
+    <Version Condition=" '$(Version)'=='' ">1.0.3</Version>
     <PackageVersion>$(Version)</PackageVersion>
     <TargetFrameworkVersion>net9.0</TargetFrameworkVersion>
     <!-- Using private apis in nuget packages -->

--- a/PeachPie Extension Libraries/Peachpie.Vendor.Stubs/build/Peachpie.Vendor.Stubs.targets
+++ b/PeachPie Extension Libraries/Peachpie.Vendor.Stubs/build/Peachpie.Vendor.Stubs.targets
@@ -1,10 +1,8 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-    <!-- Абсолютный путь к сборке задач (ОДНА СТРОКА) -->
+    <!-- Абсолютный путь к сборке задач (ОДНА СТРОКА, без переносов!) -->
     <PropertyGroup>
-        <PeachpieVendorStubsAssemblyFile Condition="'$(PeachpieVendorStubsAssemblyFile)'==''">
-            $([System.IO.Path]::GetFullPath($([System.IO.Path]::Combine('$(MSBuildThisFileDirectory)','..','lib','net6.0','Peachpie.Vendor.Stubs.dll'))))
-        </PeachpieVendorStubsAssemblyFile>
+        <PeachpieVendorStubsAssemblyFile Condition="'$(PeachpieVendorStubsAssemblyFile)'==''">$([System.IO.Path]::GetFullPath($([System.IO.Path]::Combine('$(MSBuildThisFileDirectory)','..','lib','net6.0','Peachpie.Vendor.Stubs.dll'))))</PeachpieVendorStubsAssemblyFile>
     </PropertyGroup>
 
     <!-- Подключаем задачи -->
@@ -22,8 +20,7 @@
     </PropertyGroup>
 
     <!-- Копирование готовых PHP-stubs из пакетов (их /vendor в NuGet-кэше) -->
-    <Target Name="PackageStubsRestore"
-            Condition=" '$(DesignTimeBuild)'!='true' ">
+    <Target Name="PackageStubsRestore" Condition=" '$(DesignTimeBuild)'!='true' ">
         <Message Text="PeachPie Stubs: NuGet root = $(_NuGetRoot)" Importance="Low" />
         <Message Text="PeachPie Stubs: Out = $(PeachpieStubsDir)" Importance="Low" />
         <Peachpie.Vendor.Stubs.PackageStubsRestore
@@ -34,9 +31,7 @@
     </Target>
 
     <!-- Генерация PHP-stubs из DLL пакетов -->
-    <Target Name="GeneratePhpStubs"
-            DependsOnTargets="PackageStubsRestore"
-            Condition=" '$(DesignTimeBuild)'!='true' ">
+    <Target Name="GeneratePhpStubs" DependsOnTargets="PackageStubsRestore" Condition=" '$(DesignTimeBuild)'!='true' ">
         <Message Text="PeachPie Stub Generator: Out=$(PeachpieStubsDir)" Importance="Low" />
         <Peachpie.Vendor.Stubs.GeneratePhpStubs
                 ProjectFile="$(MSBuildProjectFullPath)"
@@ -45,10 +40,8 @@
         <Message Text="PeachPie PHP stubs generated → $(PeachpieStubsDir)" Importance="High" />
     </Target>
 
-    <!-- Сводная цель: последовательно выполнить Restore stubs + Generate stubs -->
-    <Target Name="PeachpieStubs"
-            DependsOnTargets="PackageStubsRestore;GeneratePhpStubs"
-            Condition=" '$(DesignTimeBuild)'!='true' ">
+    <!-- Сводная цель -->
+    <Target Name="PeachpieStubs" DependsOnTargets="PackageStubsRestore;GeneratePhpStubs" Condition=" '$(DesignTimeBuild)'!='true' ">
         <Message Text="PeachPie Stubs: done → $(PeachpieStubsDir)" Importance="High" />
     </Target>
 

--- a/Peachpie.Avalonia.sln
+++ b/Peachpie.Avalonia.sln
@@ -7,7 +7,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{A2F46BD5-2304-4293-99DE-66B6F6DC1E57}"
 	ProjectSection(SolutionItems) = preProject
 		Directory.Build.props = Directory.Build.props
-		nuget.config = nuget.config
 		.github\workflows\PackagePublish.yml = .github\workflows\PackagePublish.yml
 	EndProjectSection
 EndProject

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 ---
 
-## ✨ Что нового в 1.0.2
+## ✨ Что нового в 1.0.3
 
 - ✅ **.NET 9** — минимальная версия SDK.
 - ✅ **События**: основной способ подписки — `.NET-подобный` через `->add(callable)` / `Hook->close()`.
@@ -37,6 +37,7 @@
 1) Установите **.NET 9 SDK**
 2) Поставьте шаблоны:
 ```powershell
+dotnet new uninstall Peachpie.Avalonia.Templates # удалите принудительно устаревшую версию шаблонов.
 dotnet new install Peachpie.Avalonia.Templates
 ```
 3) Создайте приложение:
@@ -44,7 +45,7 @@ dotnet new install Peachpie.Avalonia.Templates
 dotnet new php.avalonia.app -o MyApp
 cd MyApp
 dotnet restore
-dotnet msbuild -t:PackageStubsRestore -t:GeneratePhpStubs   # восстановит vendor-stubs и сгенерирует IDE-заглушки в vendor/Stubs
+dotnet msbuild -t:PeachpieStubs   # восстановит vendor-stubs и сгенерирует IDE-заглушки в vendor/Stubs
 dotnet run
 ```
 
@@ -102,7 +103,7 @@ IDE-заглушки (stubs) не участвуют в компиляции/р�
 
 Запуск вручную:
 ```bash
-dotnet msbuild -t:PackageStubsRestore -t:GeneratePhpStubs
+dotnet msbuild -t:PeachpieStubs
 ```
 
 ---

--- a/Templates/Peachpie.Avalonia.Templates/readme.md
+++ b/Templates/Peachpie.Avalonia.Templates/readme.md
@@ -12,6 +12,7 @@
 Требуется **.NET SDK 9+**.
 
 ```powershell
+dotnet new uninstall Peachpie.Avalonia.Templates # удалите принудительно устаревшую версию шаблонов.
 dotnet new install Peachpie.Avalonia.Templates
 ```
 
@@ -41,7 +42,7 @@ PHP Library                          php.lib                    PHP       Librar
 dotnet new php.avalonia.app -o MyApp
 cd MyApp
 dotnet restore
-dotnet msbuild -t:PackageStubsRestore -t:GeneratePhpStubs   # восстановит vendor-заглушки и сгенерирует PHP stubs в vendor/Stubs
+dotnet msbuild -t:PeachpieStubs   # восстановит vendor-заглушки и сгенерирует PHP stubs в vendor/Stubs
 dotnet run
 ```
 
@@ -56,7 +57,7 @@ dotnet run
 dotnet new php.avalonia.lib -o MyLibrary
 cd MyLibrary
 dotnet restore
-dotnet msbuild -t:PackageStubsRestore -t:GeneratePhpStubs
+dotnet msbuild -t:PeachpieStubs
 ```
 
 **Parameters:**
@@ -79,7 +80,7 @@ dotnet new php.avalonia.window -n MyNewWindow
 dotnet new php.console -o MyConsoleApp
 cd MyConsoleApp
 dotnet restore
-dotnet msbuild -t:PackageStubsRestore -t:GeneratePhpStubs
+dotnet msbuild -t:PeachpieStubs
 dotnet run
 ```
 
@@ -94,7 +95,7 @@ dotnet run
 dotnet new php.lib -o MyLibrary
 cd MyLibrary
 dotnet restore
-dotnet msbuild -t:PackageStubsRestore -t:GeneratePhpStubs
+dotnet msbuild -t:PeachpieStubs
 ```
 
 **Parameters:**
@@ -114,7 +115,7 @@ dotnet msbuild -t:PackageStubsRestore -t:GeneratePhpStubs
 Запуск:
 
 ```bash
-dotnet msbuild -t:PackageStubsRestore -t:GeneratePhpStubs
+dotnet msbuild -t:PeachpieStubs
 ```
 
 Пути формируются кроссплатформенно (`System.IO.Path.Combine`), поддерживается Windows, Linux и macOS.

--- a/Templates/Peachpie.Avalonia.Templates/templates/php/app/PeachpieAvaloniaAppTemplate.msbuildproj
+++ b/Templates/Peachpie.Avalonia.Templates/templates/php/app/PeachpieAvaloniaAppTemplate.msbuildproj
@@ -15,10 +15,10 @@
 </ItemGroup>
 
 <ItemGroup>
-    <PackageReference Include="Peachpie.Avalonia" Version="1.0.2" />
-    <PackageReference Include="Peachpie.Avalonia.Desktop" Version="1.0.2" />
-    <PackageReference Include="Peachpie.Avalonia.Fonts.Inter" Version="1.0.2" />
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Peachpie.Vendor.Stubs" Version="1.0.2" />
+    <PackageReference Include="Peachpie.Avalonia" Version="1.0.3" />
+    <PackageReference Include="Peachpie.Avalonia.Desktop" Version="1.0.3" />
+    <PackageReference Include="Peachpie.Avalonia.Fonts.Inter" Version="1.0.3" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Peachpie.Vendor.Stubs" Version="1.0.3" />
 </ItemGroup>
 
     <!-- Выполнить XAML-компиляцию после Compile. Не удалять! -->

--- a/Templates/Peachpie.Avalonia.Templates/templates/php/avalonia.library/PeachpieAvaloniaLibraryTemplate.msbuildproj
+++ b/Templates/Peachpie.Avalonia.Templates/templates/php/avalonia.library/PeachpieAvaloniaLibraryTemplate.msbuildproj
@@ -13,8 +13,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Peachpie.Avalonia" Version="1.0.2"/>
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Peachpie.Vendor.Stubs" Version="1.0.2"/>
+        <PackageReference Include="Peachpie.Avalonia" Version="1.0.3"/>
+        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Peachpie.Vendor.Stubs" Version="1.0.3"/>
     </ItemGroup>
 
     <!-- Including PHP Sdk Stubs in the nuget package -->

--- a/Templates/Peachpie.Avalonia.Templates/templates/php/console/PeachpieConsoleAppTemplate.msbuildproj
+++ b/Templates/Peachpie.Avalonia.Templates/templates/php/console/PeachpieConsoleAppTemplate.msbuildproj
@@ -11,8 +11,8 @@
 </ItemGroup>
 
 <ItemGroup>
-    <PackageReference Include="Peachpie.Community.ToolKit" Version="1.0.2" />
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Peachpie.Vendor.Stubs" Version="1.0.2" />
+    <PackageReference Include="Peachpie.Community.ToolKit" Version="1.0.3" />
+    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Peachpie.Vendor.Stubs" Version="1.0.3" />
 </ItemGroup>
 
 </Project>

--- a/Templates/Peachpie.Avalonia.Templates/templates/php/library/PeachpieLibraryTemplate.msbuildproj
+++ b/Templates/Peachpie.Avalonia.Templates/templates/php/library/PeachpieLibraryTemplate.msbuildproj
@@ -10,8 +10,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Peachpie.Community.ToolKit" Version="1.0.2" />
-        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Peachpie.Vendor.Stubs" Version="1.0.2"/>
+        <PackageReference Include="Peachpie.Community.ToolKit" Version="1.0.3" />
+        <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Peachpie.Vendor.Stubs" Version="1.0.3"/>
     </ItemGroup>
 
     <!-- Including PHP Sdk Stubs in the nuget package -->


### PR DESCRIPTION
Cвойство PeachpieVendorStubsAssemblyFile теперь заполняется в одну строку (без перевода строки и отступов внутри значения). Раньше перенос превращал значение в невалидный путь вида:

…\build\
    C:\Users\...\lib\net6.0\Peachpie.Vendor.Stubs.dll